### PR TITLE
Folding columns: override ':last-of-type' selector

### DIFF
--- a/simplegrid.css
+++ b/simplegrid.css
@@ -138,7 +138,7 @@ body {
 		padding-right: 0px;
 	}
 	
-	[class*='col-'] {
+	[class*='col-'], [class*='col-']:last-of-type {
 		width: auto;
 		float: none;
 		margin-left: 0px;


### PR DESCRIPTION
When folding non-padded grids, the last col-*-element has no padding on the right-hand side, because the definition within the media query is overruled by the previous definition within the ':last-of-type'-selector.

I think this behavior is unintended and propose to specifically include :last-of-type.
