### PR TITLE
Allow using different types of elements in columns

### DIFF
--- a/simplegrid.css
+++ b/simplegrid.css
@@ -21,7 +21,7 @@ body {
 	padding-right: 20px;
 }
 
-[class*='col-']:last-of-type {
+[class*='col-']:last-child {
 	padding-right: 0px;
 }
 
@@ -43,7 +43,7 @@ body {
 	padding: 20px 0 0px 20px;
 }
 
-.grid-pad > [class*='col-']:last-of-type {
+.grid-pad > [class*='col-']:last-child {
 	padding-right: 20px;
 }
 


### PR DESCRIPTION
This pull request is to allow the use of different types of elements when creating columns using Simple-Grid. It replaces the :last-of-type selectors with :last-child ones. This kind of markup is then possible :

``` html
<article class="grid">
    <div class="col-10-12"><!-- Content --></div>
    <aside class="col-2-12"><!-- Content --></div>
</article>
```
