### PR TITLE
fix ipad portrait issue.

### DIFF
--- a/simplegrid.css
+++ b/simplegrid.css
@@ -24,7 +24,7 @@ body {
 .grid {
 	width: 100%;
 	max-width: 1140px;
-	min-width: 755px;
+	min-width: 748px; /* when using padded grid on ipad in portrait mode, width should be viewport-width - padding = (768 - 20) = 748. actually, it should be even smaller to allow for padding of grid containing element */
 	margin: 0 auto;
 	overflow: hidden;
 }


### PR DESCRIPTION
When using padded grid on iPad in portrait mode, width should be viewport-width - padding = (768 - 20) = 748. Actually, it should be even smaller to allow for padding of grid containing element. Current value of min-width does not allow for a padded grid to fit on iPad in portrait. 