### PR TITLE
Fix to prevent empty columns collapsing horizontally.

### DIFF
--- a/simplegrid.css
+++ b/simplegrid.css
@@ -18,6 +18,7 @@ body {
 
 [class*='col-'] {
 	float: left;
+  min-height: 1px;
 	padding-right: 20px; /* column-space */
 }
 


### PR DESCRIPTION
Empty columns get collapsed horizontally when floated left. I've added a min-height of 1px to all columns to fix this issue.

More information:
http://css-tricks.com/make-sure-columns-dont-collapse-horizontally/