### PR TITLE
Add a mobile-push-right class

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The first column of content in your grid will always be floated left. If you wou
   &lt;/div&gt;
 &lt;/div&gt;
 </pre>
-To hide a element (column, div, a, etc.) on mobile and tablets you can add the class <code>hide-on-mobile</code> to it.
+To hide a element (column, div, a, etc.) on mobile and tablets you can add the class <code>hide-on-mobile</code> to it. To float a column to the right on mobile, just add the class <code>mobile-push-right</code> (especially useful when not stacking columns on mobile).
 </p>
 
 <h3>Preview</h3>

--- a/simplegrid.css
+++ b/simplegrid.css
@@ -279,6 +279,10 @@
 		width: 58.33%
 	}
 
+	.mobile-push-right {
+		float: right;
+	}
+
 	.hide-on-mobile {
 		display: none !important;
 		width: 0;


### PR DESCRIPTION
I ran into trouble trying to <code>push-right</code> a column on mobile that I didn't want stacked. Adding a mobile equilvalent to <code>push-right</code> took care of it nicely. Opted for a new class name <code>mobile-push-right</code> to stick with the established style and not affect sites which may rely on <code>push-right</code> doing nothing for mobile. May also address issue #44.
